### PR TITLE
fix camera.projectionMatrixInverse of THREE@>=103

### DIFF
--- a/index.js
+++ b/index.js
@@ -41,6 +41,8 @@ const EVENTS = [
     'touchend'
 ];
 
+const MATRIX4 = new THREE.Matrix4();
+
 /**
  * A Layer to render with THREE.JS (http://threejs.org), the most popular library for WebGL. <br>
  *
@@ -134,7 +136,7 @@ class ThreeLayer extends maptalks.CanvasLayer {
         const center = polygon.getCenter();
         const centerPt = this.coordinateToVector3(center);
         const shell = polygon.getShell();
-        const outer = shell.map(c => this.coordinateToVector3(c).sub(centerPt)).reverse();
+        const outer = shell.map(c => this.coordinateToVector3(c).sub(centerPt));
         const shape = new THREE.Shape(outer);
         const holes = polygon.getHoles();
 
@@ -672,8 +674,10 @@ class ThreeRenderer extends maptalks.renderer.CanvasLayerRenderer {
 
     _syncCamera() {
         const map = this.getMap();
-        this.camera.matrix.elements = map.cameraWorldMatrix;
-        this.camera.projectionMatrix.elements = map.projMatrix;
+        const camera = this.camera;
+        camera.matrix.elements = map.cameraWorldMatrix;
+        camera.projectionMatrix.elements = map.projMatrix;
+        camera.projectionMatrixInverse.elements = MATRIX4.getInverse(camera.projectionMatrix).elements;
     }
 
     _createGLContext(canvas, options) {


### PR DESCRIPTION
因为THREE从103版开始，raycaster中camera.projectionMatrixInverse的计算方式发生改变，导致raycaster不能正常工作。

改为手动计算camera.projectionMatrixInverse即能解决这个问题