### PR TITLE
fit for GroupGLLayer

### DIFF
--- a/types/maptalks/index.d.ts
+++ b/types/maptalks/index.d.ts
@@ -85,7 +85,7 @@ declare namespace renderer {
     getMap(): Map
     completeRender(): void
     remove(): void
-
+    setToRedraw(): void
 
   }
 }
@@ -108,10 +108,12 @@ declare class CanvasLayer {
   constructor(id: string, options: Object)
   fire(eventType: string, params: any): boolean
   getMap(): Map
+  redraw(): void
   static mergeOptions(options: Object): void
   onAdd(): void
   onRemove(): void
   _getRenderer(): any
+  getRenderer(): any
   static registerRenderer(type: string, render: any): void
   onCanvasCreate(...params: any[]): void
 


### PR DESCRIPTION
主要原理是如果GroupGLLayer需要绘制到帧缓冲时，把 THREE.WebglRenderTarget 中的webgl原生fbo对象替换为 GroupGLLayer 中的即可。

因为涉及到一些修改，测试时有以下两个要求。
* gl版本升级到 0.65.1
* maptalks需要采用master分支上的编译版本