### PR TITLE
改为整体缩放场景的海拔高度

### DIFF
--- a/demo-bak/buildings.html
+++ b/demo-bak/buildings.html
@@ -47,12 +47,11 @@ var threeLayer = new maptalks.ThreeLayer('t', {
     forceRenderOnMoving : true,
     forceRenderOnRotating : true
 });
-threeLayer.prepareToDraw = function (gl, scene, camera) {
+threeLayer.prepareToDraw = function (gl, scene, camera, worldGroup) {
     var me = this;
     var light = new THREE.DirectionalLight(0xffffff);
     light.position.set(0, -10, 10).normalize();
     scene.add(light);
-    const worldGroup = scene.children[0];
 
     features.forEach(function (g) {
         var heightPerLevel = 10;

--- a/demo-bak/buildings.html
+++ b/demo-bak/buildings.html
@@ -52,6 +52,7 @@ threeLayer.prepareToDraw = function (gl, scene, camera) {
     var light = new THREE.DirectionalLight(0xffffff);
     light.position.set(0, -10, 10).normalize();
     scene.add(light);
+    const worldGroup = scene.children[0];
 
     features.forEach(function (g) {
         var heightPerLevel = 10;
@@ -64,9 +65,9 @@ threeLayer.prepareToDraw = function (gl, scene, camera) {
 
         var mesh = me.toExtrudeMesh(maptalks.GeoJSON.toGeometry(g), levels * heightPerLevel, m, levels * heightPerLevel);
         if (Array.isArray(mesh)) {
-          scene.add.apply(scene, mesh);
+          worldGroup.add.apply(worldGroup, mesh);
         } else {
-          scene.add(mesh);
+          worldGroup.add(mesh);
         }
     });
 };
@@ -78,7 +79,7 @@ var raycaster = new THREE.Raycaster();
 document.addEventListener('click', function (event) {
     event.preventDefault();
     var mouse = new THREE.Vector2();
-    
+
     let dpr = map.getDevicePixelRatio();
     if(!dpr)
     {

--- a/demo-bak/custom-text.html
+++ b/demo-bak/custom-text.html
@@ -102,10 +102,10 @@
             if (!Array.isArray(meshes)) {
                 meshes = [meshes];
             }
-            const scene = this.getScene();
+            const worldGroup = this.getWorldGroup();
             meshes.forEach(mesh => {
                 if (mesh instanceof maptalks.BaseObject) {
-                    scene.add(mesh.getObject3d());
+                    worldGroup.add(mesh.getObject3d());
                     if (!mesh.isAdd) {
                         mesh.isAdd = true;
                         mesh._fire('add', { target: mesh });
@@ -124,7 +124,7 @@
                         this._animationBaseObjectMap[mesh.getObject3d().uuid] = mesh;
                     }
                 } else if (mesh instanceof THREE.Object3D) {
-                    scene.add(mesh);
+                    worldGroup.add(mesh);
                 }
             });
             this._zoomend();

--- a/demo/buildings-VertexColors.html
+++ b/demo/buildings-VertexColors.html
@@ -62,12 +62,11 @@
         var meshs = [];
         var material = new THREE.MeshLambertMaterial({ color: '#fff', transparent: true });
         var highlightmaterial = new THREE.MeshBasicMaterial({ color: 'yellow', transparent: true });
-        threeLayer.prepareToDraw = function (gl, scene, camera) {
+        threeLayer.prepareToDraw = function (gl, scene, camera, worldGroup) {
             var light = new THREE.DirectionalLight(0xffffff);
             light.position.set(0, -10, 10).normalize();
             scene.add(light);
             scene.add(new THREE.AmbientLight('#fff', 0.2));
-            var worldGroup = scene.children[0];
 
             // var material = new THREE.MeshBasicMaterial({ color: '#3e35cf' });
             // material.vertexColors = THREE.VertexColors;

--- a/demo/buildings-VertexColors.html
+++ b/demo/buildings-VertexColors.html
@@ -67,6 +67,7 @@
             light.position.set(0, -10, 10).normalize();
             scene.add(light);
             scene.add(new THREE.AmbientLight('#fff', 0.2));
+            var worldGroup = scene.children[0];
 
             // var material = new THREE.MeshBasicMaterial({ color: '#3e35cf' });
             // material.vertexColors = THREE.VertexColors;
@@ -112,9 +113,9 @@
                 // initVertexColors(mesh.geometry, '#2d2f61', '#fff');
                 meshs.push(mesh);
                 // if (Array.isArray(mesh)) {
-                //     scene.add.apply(scene, mesh);
+                //     worldGroup.add.apply(worldGroup, mesh);
                 // } else {
-                //     scene.add(mesh);
+                //     worldGroup.add(mesh);
                 // }
             });
             threeLayer.addMesh(meshs);

--- a/demo/extrudeline.html
+++ b/demo/extrudeline.html
@@ -54,8 +54,7 @@
             forceRenderOnRotating: true
             // animation: true
         });
-        threeLayer.prepareToDraw = function (gl, scene, camera) {
-            var worldGroup = scene.children[0];
+        threeLayer.prepareToDraw = function (gl, scene, camera, worldGroup) {
             var light = new THREE.DirectionalLight(0xffffff);
             light.position.set(0, -10, 10).normalize();
             scene.add(light);

--- a/demo/extrudeline.html
+++ b/demo/extrudeline.html
@@ -55,6 +55,7 @@
             // animation: true
         });
         threeLayer.prepareToDraw = function (gl, scene, camera) {
+            var worldGroup = scene.children[0];
             var light = new THREE.DirectionalLight(0xffffff);
             light.position.set(0, -10, 10).normalize();
             scene.add(light);
@@ -86,9 +87,9 @@
                 // initVertexColors(mesh.geometry, '#2d2f61', '#fff');
                 meshs.push(mesh);
                 // if (Array.isArray(mesh)) {
-                //     scene.add.apply(scene, mesh);
+                //     worldGroup.add.apply(worldGroup, mesh);
                 // } else {
-                //     scene.add(mesh);
+                //     worldGroup.add(mesh);
                 // }
             });
             threeLayer.addMesh(meshs);

--- a/demo/line.html
+++ b/demo/line.html
@@ -62,8 +62,7 @@
         });
 
 
-        threeLayer.prepareToDraw = function (gl, scene, camera) {
-            var worldGroup = scene.children[0];
+        threeLayer.prepareToDraw = function (gl, scene, camera, worldGroup) {
             var light = new THREE.DirectionalLight(0xffffff);
             light.position.set(0, -10, 10).normalize();
             scene.add(light);

--- a/demo/line.html
+++ b/demo/line.html
@@ -63,6 +63,7 @@
 
 
         threeLayer.prepareToDraw = function (gl, scene, camera) {
+            var worldGroup = scene.children[0];
             var light = new THREE.DirectionalLight(0xffffff);
             light.position.set(0, -10, 10).normalize();
             scene.add(light);
@@ -95,9 +96,9 @@
                 // initVertexColors(mesh.geometry, '#2d2f61', '#fff');
                 meshs.push(mesh);
                 // if (Array.isArray(mesh)) {
-                //     scene.add.apply(scene, mesh);
+                //     worldGroup.add.apply(worldGroup, mesh);
                 // } else {
-                //     scene.add(mesh);
+                //     worldGroup.add(mesh);
                 // }
             });
             threeLayer.addMesh(meshs);

--- a/src/index.ts
+++ b/src/index.ts
@@ -171,7 +171,7 @@ class ThreeLayer extends maptalks.CanvasLayer {
      * Draw method of ThreeLayer
      * In default, it calls renderScene, refresh the camera and the scene
      */
-    draw(gl, view, scene, camera, timeStamp, context) {
+    draw(gl, view, scene, camera, worldGroup, timeStamp, context) {
         this.renderScene(context, this);
     }
 
@@ -179,7 +179,7 @@ class ThreeLayer extends maptalks.CanvasLayer {
      * Draw method of ThreeLayer when map is interacting
      * In default, it calls renderScene, refresh the camera and the scene
      */
-    drawOnInteracting(gl, view, scene, camera, event, timeStamp, context) {
+    drawOnInteracting(gl, view, scene, camera, worldGroup, event, timeStamp, context) {
         this.renderScene(context, this);
     }
 
@@ -1459,11 +1459,11 @@ if (maptalks.renderer.LayerAbstractRenderer) {
         _predrawed: boolean;
 
         getPrepareParams(): Array<any> {
-            return [this.scene, this.camera];
+            return [this.scene, this.camera, this.worldGroup];
         }
 
         getDrawParams(): Array<any> {
-            return [this.scene, this.camera];
+            return [this.scene, this.camera, this.worldGroup];
         }
 
 

--- a/src/index.ts
+++ b/src/index.ts
@@ -332,22 +332,23 @@ class ThreeLayer extends maptalks.CanvasLayer {
         if ((altitude === 0) || (!maptalks.Util.isNumber(altitude))) {
             return new THREE.Vector3(0, 0, 0);
         }
-        const map = this.getMap();
-        if (map.altitudeToPoint) {
-            const res = getGLRes(map);
-            let z = map.altitudeToPoint(altitude, res);
-            if (altitude < 0 && z > 0) {
-                z = -z;
-            }
-            if (out) {
-                out.x = z;
-                out.y = z;
-                out.z = 0;
-                return out;
-            }
-            return new THREE.Vector3(z, z, 0);
-        }
-        return this.distanceToVector3(altitude, altitude, coord);
+        // const map = this.getMap();
+        // if (map.altitudeToPoint) {
+        //     const res = getGLRes(map);
+        //     let z = map.altitudeToPoint(altitude, res);
+        //     if (altitude < 0 && z > 0) {
+        //         z = -z;
+        //     }
+        //     if (out) {
+        //         out.x = z;
+        //         out.y = z;
+        //         out.z = 0;
+        //         return out;
+        //     }
+        //     return new THREE.Vector3(z, z, 0);
+        // }
+        // return this.distanceToVector3(altitude, altitude, coord);
+        return new THREE.Vector3(altitude, altitude1, 0);
     }
 
     /**
@@ -668,13 +669,13 @@ class ThreeLayer extends maptalks.CanvasLayer {
 
 
     getMeshes(): Array<THREE.Object3D | BaseObject> {
-        const scene = this.getScene();
-        if (!scene) {
+        const worldGroup = this.getWorldGroup();
+        if (!worldGroup) {
             return [];
         }
         const meshes = [];
-        for (let i = 0, len = scene.children.length; i < len; i++) {
-            const child = scene.children[i];
+        for (let i = 0, len = worldGroup.children.length; i < len; i++) {
+            const child = worldGroup.children[i];
             if (child instanceof THREE.Object3D && !(child instanceof THREE.Camera)) {
                 meshes.push(child['__parent'] || child);
             }
@@ -696,14 +697,14 @@ class ThreeLayer extends maptalks.CanvasLayer {
     }
 
     clearMesh() {
-        const scene = this.getScene();
-        if (!scene) {
+        const worldGroup = this.getWorldGroup();
+        if (!worldGroup) {
             return this;
         }
-        for (let i = scene.children.length - 1; i >= 0; i--) {
-            const child = scene.children[i];
+        for (let i = worldGroup.children.length - 1; i >= 0; i--) {
+            const child = worldGroup.children[i];
             if (child instanceof THREE.Object3D && !(child instanceof THREE.Camera)) {
-                scene.remove(child);
+                worldGroup.remove(child);
                 const parent = child['__parent'];
                 if (parent && parent instanceof BaseObject) {
                     parent.isAdd = false;
@@ -738,6 +739,14 @@ class ThreeLayer extends maptalks.CanvasLayer {
         const renderer = this['_getRenderer']();
         if (renderer) {
             return renderer.scene;
+        }
+        return null;
+    }
+
+    getWorldGroup(): THREE.Group {
+        const renderer = this['_getRenderer']();
+        if (renderer) {
+            return renderer.worldGroup;
         }
         return null;
     }
@@ -819,10 +828,10 @@ class ThreeLayer extends maptalks.CanvasLayer {
         if (!Array.isArray(meshes)) {
             meshes = [meshes];
         }
-        const scene = this.getScene();
+        const worldGroup = this.getWorldGroup();
         meshes.forEach(mesh => {
             if (mesh instanceof BaseObject) {
-                scene.add(mesh.getObject3d());
+                worldGroup.add(mesh.getObject3d());
                 if (!mesh.isAdd) {
                     mesh.isAdd = true;
                     mesh.options.layer = this;
@@ -832,7 +841,7 @@ class ThreeLayer extends maptalks.CanvasLayer {
                     this._animationBaseObjectMap[mesh.getObject3d().uuid] = mesh;
                 }
             } else if (mesh instanceof THREE.Object3D) {
-                scene.add(mesh);
+                worldGroup.add(mesh);
             }
             const index = this._meshes.indexOf(mesh);
             if (index === -1) {
@@ -941,6 +950,7 @@ class ThreeLayer extends maptalks.CanvasLayer {
             mouse = this._mouse,
             camera = this.getCamera(),
             scene = this.getScene(),
+            worldGroup = this.getWorldGroup(),
             size = this.getMap().getSize();
         //fix Errors will be reported when the layer is not initialized
         if (!scene) {
@@ -957,7 +967,7 @@ class ThreeLayer extends maptalks.CanvasLayer {
         //set linePrecision for THREE.Line
         setRaycasterLinePrecision(raycaster, this._getLinePrecision(this.getMap().getResolution()));
         const children: Array<THREE.Object3D> = [], hasidentifyChildren: Array<BaseObject> = [];
-        scene.children.forEach(mesh => {
+        worldGroup.children.forEach(mesh => {
             const parent = mesh['__parent'];
             if (parent && parent.getOptions) {
                 const baseObject = parent as BaseObject;
@@ -1118,6 +1128,7 @@ class ThreeLayer extends maptalks.CanvasLayer {
     _emptyIdentify(options: any = {}) {
         const event = options.domEvent;
         const scene = this.getScene();
+        const worldGroup = this.getWorldGroup();
         if (!scene) {
             return this;
         }
@@ -1126,8 +1137,8 @@ class ThreeLayer extends maptalks.CanvasLayer {
             return this;
         }
         const e = map['_getEventParams'] ? map['_getEventParams'](event) : this._getEventParams(event);
-        for (let i = 0, len = scene.children.length; i < len; i++) {
-            const child = scene.children[i] || {};
+        for (let i = 0, len = worldGroup.children.length; i < len; i++) {
+            const child = worldGroup.children[i] || {};
             const parent = child['__parent'];
             if (parent) {
                 (parent as BaseObject).fire('empty', Object.assign({}, e, { target: parent }));
@@ -1218,10 +1229,10 @@ class ThreeLayer extends maptalks.CanvasLayer {
             return this;
         }
         const baseObjects = this.identify(coordinate, { count });
-        const scene = this.getScene();
-        if (baseObjects.length === 0 && scene) {
-            for (let i = 0, len = scene.children.length; i < len; i++) {
-                const child = scene.children[i] || {};
+        const worldGroup = this.getWorldGroup();
+        if (baseObjects.length === 0 && worldGroup) {
+            for (let i = 0, len = worldGroup.children.length; i < len; i++) {
+                const child = worldGroup.children[i] || {};
                 const parent = child['__parent'];
                 if (parent) {
                     (parent as BaseObject).fire('empty', Object.assign({}, e, { target: parent }));
@@ -1314,12 +1325,12 @@ class ThreeLayer extends maptalks.CanvasLayer {
      *map zoom event
      */
     _zoomend() {
-        const scene = this.getScene();
-        if (!scene) {
+        const worldGroup = this.getWorldGroup();
+        if (!worldGroup) {
             return;
         }
         const zoom = this.getMap().getZoom();
-        scene.children.forEach(mesh => {
+        worldGroup.children.forEach(mesh => {
             const parent = mesh['__parent'];
             if (parent && parent.getOptions) {
                 const baseObject = parent as BaseObject;
@@ -1432,6 +1443,7 @@ let ThreeRenderer;
 if (maptalks.renderer.LayerAbstractRenderer) {
     class ThreeGLRenderer extends maptalks.renderer.LayerAbstractRenderer {
         scene: THREE.Scene;
+        worldGroup: THREE.Group;
         camera: THREE.Camera;
         canvas: any
         layer: ThreeLayer;
@@ -1498,7 +1510,11 @@ if (maptalks.renderer.LayerAbstractRenderer) {
             this.context = renderer;
 
             const scene = this.scene = new THREE.Scene();
+            this.worldGroup = new THREE.Group();
+            scene.add(this.worldGroup);
             const map = this.layer.getMap();
+            const zScale = map.altitudeToPoint(100, map.getGLRes()) / 100;
+            this.worldGroup.scale.set(1, 1, zScale);
             const fov = map.getFov() * Math.PI / 180;
             //@ts-ignore
             const camera = this.camera = new THREE.PerspectiveCamera(fov, map.width / map.height, map.cameraNear, map.cameraFar);
@@ -1586,7 +1602,8 @@ if (maptalks.renderer.LayerAbstractRenderer) {
                 renderTargetProps[KEY_FBO] = context.renderTarget.getFramebuffer(context.renderTarget.fbo);
                 this.context.setRenderTarget(this._renderTarget);
                 const bloomEnable = context.bloom === 1 && context.sceneFilter;
-                const object3ds = this.scene.children || [];
+                const object3ds = this.worldGroup.children || [];
+
                 //是否是bloom渲染帧
                 let isBloomFrame = false;
                 if (bloomEnable) {


### PR DESCRIPTION
解决 #700 中海拔值超出精度后，高度和maptalks不一致的问题

### 修改内容：
* renderer上增加了worldGroup，mesh改为添加到worldGroup中，并在worldGroup.scale.z上设置海拔的整体缩放系数zScale
* `altitudeToVector3` 改为直接返回原始海拔值
* 修改了clearMesh，identify等需要遍历children的方法，改为从worldGroup上获取children
* parepareToDraw和draw方法的参数中，增加了worldGroup，变为 `(scene, camera, worldGroup)`

### 第三方mesh 的高度问题
* 原逻辑中，其他来源mesh（例如GLTFLoader）加入到 scene 的高度会和maptalks不一致，需要手动计算z轴缩放系数并设置，新的逻辑里，第三方mesh加入到worldGroup中高度就会自动缩放为与maptalks一致了

### Breaking changes：
* mesh不再直接添加到scene上，如果业务存在通过scene直接操作mesh的逻辑会产生错误

修正后，原 #700 中的重现代码已经正常工作了：
<img width="260" height="135" alt="image" src="https://github.com/user-attachments/assets/9b0012ec-7105-4539-936f-78fb79f780b2" />
