### PR TITLE
only clear canvas when threeLayer is in MapCanvasRenderer

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -747,6 +747,7 @@ class ThreeLayer extends maptalks.CanvasLayer {
         const renderer = this['_getRenderer']();
         if (renderer) {
             renderer.clearCanvas();
+
             renderer.renderScene(context);
             //外部调用时，直接redraw
             if (!layer) {
@@ -1548,8 +1549,12 @@ if (maptalks.renderer.LayerAbstractRenderer) {
             if (!this.canvas) {
                 return;
             }
+            const mapRenderer = this.getMap().getRenderer();
+            if (!this.gl.wrap &&
+                this.canvas !== mapRenderer.canvas) {
+                this.context.clear();
+            }
 
-            this.context.clear();
         }
 
         renderScene(context) {


### PR DESCRIPTION
如果map的renderer是gl，renderScene上的clearCanvas会把map的canvas给清空。
以下两种情况不clearCanvas：
* ThreeLayer的canvas和map的canvas是同一个
* ThreeLayer在GroupGLLayer中